### PR TITLE
Remove checksum badge from README files for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [🇧🇷 Read this documentation in Portuguese](docs/README.pt-BR.md)
 
 [![Build](https://github.com/faelmori/goforge/actions/workflows/release.yml/badge.svg)](https://github.com/faelmori/goforge/actions/workflows/release.yml)
-[![Checksum](https://github.com/faelmori/goforge/actions/workflows/checksum.yml/badge.svg)](https://github.com/faelmori/goforge/actions/workflows/checksum.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-%3E=1.20-blue)](go.mod)
 [![Releases](https://img.shields.io/github/v/release/faelmori/goforge?include_prereleases)](https://github.com/faelmori/goforge/releases)

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -1,7 +1,6 @@
 # 🚀 GoForge: Automação, CLI Moderna e Estrutura Profissional para Módulos Go
 
 [![Build](https://github.com/faelmori/goforge/actions/workflows/release.yml/badge.svg)](https://github.com/faelmori/goforge/actions/workflows/release.yml)
-[![Checksum](https://github.com/faelmori/goforge/actions/workflows/checksum.yml/badge.svg)](https://github.com/faelmori/goforge/actions/workflows/checksum.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-%3E=1.20-blue)](go.mod)
 [![Releases](https://img.shields.io/github/v/release/faelmori/goforge?include_prereleases)](https://github.com/faelmori/goforge/releases)


### PR DESCRIPTION
Eliminate the checksum badge from the README files to enhance clarity.

Signed-off-by: Rafael Mori <faelmori@gmail.com>