### PR TITLE
chore: atualiza versão para 1.0.2 no manifest.json

### DIFF
--- a/info/manifest.json
+++ b/info/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GoForge",
   "application": "goforge",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": false,
   "published": true,
   "aliases": ["goforge"],


### PR DESCRIPTION
This pull request includes a minor version update for the `GoForge` application. The `version` field in the `info/manifest.json` file has been updated from `1.0.1` to `1.0.2`, likely indicating a small update or bug fix.